### PR TITLE
more information for ValidationError

### DIFF
--- a/META.json
+++ b/META.json
@@ -48,6 +48,7 @@
             "Clone" : "0",
             "Data::Validate::URI" : "0",
             "JSON::PP" : "0",
+            "JSON::Pointer" : "0",
             "JSON::XS" : "0",
             "List::MoreUtils" : "0",
             "Scalar::Util" : "0",

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Valiemon - data validator based on json schema
     # $error => object Valiemon::ValidationError
     # $error->position => '/properties/price/type'
 
+    # shortcut for JSON Pointer
+    $validator->point($validator->schema, '/type') # => 'object'
+
 # DESCRIPTION
 
 This module is under development!

--- a/cpanfile
+++ b/cpanfile
@@ -4,6 +4,7 @@ requires 'Clone';
 requires 'Data::Validate::URI';
 requires 'JSON::PP';
 requires 'JSON::XS';
+requires 'JSON::Pointer';
 requires 'List::MoreUtils';
 requires 'Scalar::Util';
 requires 'Test::Deep';

--- a/lib/Valiemon.pm
+++ b/lib/Valiemon.pm
@@ -9,6 +9,8 @@ use Valiemon::Primitives;
 use Valiemon::Context;
 use Valiemon::Attributes qw(attr);
 
+use JSON::Pointer;
+
 use Class::Accessor::Lite (
     ro => [qw(schema options pos schema_cache)],
 );
@@ -89,6 +91,10 @@ sub resolve_ref {
     };
 }
 
+sub point {
+    my ($self, $document, $pointer) = @_;
+    JSON::Pointer->get($document, $pointer);
+}
 
 1;
 
@@ -124,6 +130,9 @@ Valiemon - data validator based on json schema
     # $res   => 0
     # $error => object Valiemon::ValidationError
     # $error->position => '/properties/price/type'
+
+    # shortcut for JSON Pointer
+    $validator->point($validator->schema, '/type') # => 'object'
 
 =head1 DESCRIPTION
 

--- a/lib/Valiemon.pm
+++ b/lib/Valiemon.pm
@@ -42,6 +42,10 @@ sub validate {
         if ($attr) {
             my ($is_valid, $error) = $attr->is_valid($context, $schema, $data);
             unless ($is_valid) {
+                $error->set_detail(
+                    expected => $schema,
+                    actual => $data,
+                );
                 $context->push_error($error);
                 next;
             }

--- a/lib/Valiemon/ValidationError.pm
+++ b/lib/Valiemon/ValidationError.pm
@@ -4,7 +4,7 @@ use warnings;
 use utf8;
 
 use Class::Accessor::Lite (
-    ro => [qw(attribute position)],
+    ro => [qw(attribute position expect actual)],
 );
 
 sub new {
@@ -13,6 +13,13 @@ sub new {
         attribute => $attr,
         position  => $position,
     }, $class;
+}
+
+sub set_detail {
+    my ($self, %params) = @_;
+
+    $self->{expected} = $params{expected};
+    $self->{actual} = $params{actual};
 }
 
 sub as_message {

--- a/t/01-validator.t
+++ b/t/01-validator.t
@@ -16,4 +16,31 @@ subtest 'point' => sub {
     is_deeply $v->point($v->schema, '/other'), undef;
 };
 
+subtest 'validate' => sub {
+    my $v = Valiemon->new({
+        type => 'array',
+        items => { type => 'integer' },
+    });
+
+    subtest 'pass' => sub {
+        my ($result, $error) = $v->validate([1,2,3]);
+        ok $result;
+        ok ! $error;
+    };
+
+    subtest 'ValidationError has position, attribute, expected, actual' => sub {
+        my ($result, $error) = $v->validate([1,2,'a']);
+        ok !$result;
+        isa_ok $error, 'Valiemon::ValidationError';
+        is_deeply $error, {
+            position => '/items/2/type',
+            attribute => 'Valiemon::Attributes::Type',
+            expected => {
+                type => 'integer'
+            },
+            actual => 'a',
+        };
+    };
+};
+
 done_testing;

--- a/t/01-validator.t
+++ b/t/01-validator.t
@@ -5,4 +5,15 @@ use Test::More;
 
 use_ok 'Valiemon';
 
+subtest 'point' => sub {
+    my $v = Valiemon->new({
+        type => 'array',
+        items => { type => 'integer' },
+    });
+
+    is_deeply $v->point($v->schema, ''), $v->schema;
+    is_deeply $v->point($v->schema, '/items'), { type => 'integer' };
+    is_deeply $v->point($v->schema, '/other'), undef;
+};
+
 done_testing;


### PR DESCRIPTION
I added these attributes to ValidationError.
- expected: the schema which fails the validation
- actual: the input data which fails the validation

This is useful for debugging.

``` perl
my $v = Valiemon->new({
    type => 'array',
    items => { type => 'integer' },
});

my ($result, $error) = $v->validate([1,2,'a']);
# $error => {
#     position => '/items/2/type',
#     attribute => 'Valiemon::Attributes::Type',
#     expected => {
#         type => 'integer'
#     },
#     actual => 'a',
# };
```
