### PR TITLE
more information for ValidationError

### DIFF
--- a/lib/Valiemon.pm
+++ b/lib/Valiemon.pm
@@ -40,6 +40,10 @@ sub validate {
         if ($attr) {
             my ($is_valid, $error) = $attr->is_valid($context, $schema, $data);
             unless ($is_valid) {
+                $error->set_detail(
+                    expected => $schema,
+                    actual => $data,
+                );
                 $context->push_error($error);
                 next;
             }

--- a/lib/Valiemon/ValidationError.pm
+++ b/lib/Valiemon/ValidationError.pm
@@ -4,7 +4,7 @@ use warnings;
 use utf8;
 
 use Class::Accessor::Lite (
-    ro => [qw(attribute position)],
+    ro => [qw(attribute position expect actual)],
 );
 
 sub new {
@@ -13,6 +13,13 @@ sub new {
         attribute => $attr,
         position  => $position,
     }, $class;
+}
+
+sub set_detail {
+    my ($self, %params) = @_;
+
+    $self->{expected} = $params{expected};
+    $self->{actual} = $params{actual};
 }
 
 sub as_message {

--- a/t/01-validator.t
+++ b/t/01-validator.t
@@ -5,4 +5,31 @@ use Test::More;
 
 use_ok 'Valiemon';
 
+subtest 'validate' => sub {
+    my $v = Valiemon->new({
+        type => 'array',
+        items => { type => 'integer' },
+    });
+
+    subtest 'pass' => sub {
+        my ($result, $error) = $v->validate([1,2,3]);
+        ok $result;
+        ok ! $error;
+    };
+
+    subtest 'ValidationError has position, attribute, expected, actual' => sub {
+        my ($result, $error) = $v->validate([1,2,'a']);
+        ok !$result;
+        isa_ok $error, 'Valiemon::ValidationError';
+        is_deeply $error, {
+            position => '/items/2/type',
+            attribute => 'Valiemon::Attributes::Type',
+            expected => {
+                type => 'integer'
+            },
+            actual => 'a',
+        };
+    };
+};
+
 done_testing;


### PR DESCRIPTION
I added these attributes to ValidationError.
- expected: the schema which fails the validation
- actual: the input data which fails the validation

This is useful for debugging.

``` perl
my $v = Valiemon->new({
    type => 'array',
    items => { type => 'integer' },
});

my ($result, $error) = $v->validate([1,2,'a']);
# $error => {
#     position => '/items/2/type',
#     attribute => 'Valiemon::Attributes::Type',
#     expected => {
#         type => 'integer'
#     },
#     actual => 'a',
# };
```
