### PR TITLE
Fix date-time format validation for invalid suffixes

### DIFF
--- a/lib/Valiemon/Attributes/Format.pm
+++ b/lib/Valiemon/Attributes/Format.pm
@@ -34,7 +34,7 @@ sub is_valid {
 sub _validate_date_time {
     my ($data) = @_;
     # TODO: check range of value (date-month must be `01-12` etc...)
-    $data =~ /\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})/ ? 1 :  0;
+    $data =~ /\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})\z/ ? 1 :  0;
 }
 
 sub _validate_uri {

--- a/t/03-attr-format.t
+++ b/t/03-attr-format.t
@@ -35,6 +35,12 @@ subtest 'date-time' => sub {
         is $error->position, '/format';
     };
 
+    subtest 'invalid(suffix)' => sub {
+        ($res, $error) = $v->validate('2014-01-01T00:00:00Zx');
+        ok !$res;
+        is $error->position, '/format';
+    };
+
     subtest 'invalid(range)' => sub {
         TODO : {
             local $TODO = 'RFC3339 range of value';


### PR DESCRIPTION
I noticed that Valiemon accepts trailing characters for `date-time` format (for example; `2021-02-17T00:00:00Zfoo`). This is invalid and should not be accepted.